### PR TITLE
Update test_command_generator.rb

### DIFF
--- a/lib/scan/test_command_generator.rb
+++ b/lib/scan/test_command_generator.rb
@@ -46,7 +46,6 @@ module Scan
 
         actions = []
         actions << :clean if config[:clean]
-        actions << :build
         actions << :test
 
         actions


### PR DESCRIPTION
This is to remove the build command from scan. Xcodebuild test automatically builds and runs tests. Adding build to that makes it redundant and increases execution time.
